### PR TITLE
Add basic setup for queue and gemini API calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # Gemini API Competition
+
+## Chat Systems Microservice
+
+### Steps to run
+
+1. Run rabbitmq in docker:
+
+```
+docker run -d -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.13-management
+```
+
+2. Run `gemini_executor.py` that consumes values from queue and prompts Gemini:
+
+```
+python gemini_executor --gemini-api-key <YOUR-GEMINI-KEY>
+```
+
+3. Run `send_prompt.py` that is for testing the executor, sends a prompt to queue:
+
+```
+python send_prompt.py <PROMPT>
+```
+
+At this point you should see the output of Gemini from `gemini_executor.py`.

--- a/microservices/chat-agents/constants.py
+++ b/microservices/chat-agents/constants.py
@@ -1,0 +1,1 @@
+GEMINI_MODEL = "gemini-1.5-flash"

--- a/microservices/chat-agents/environment.py
+++ b/microservices/chat-agents/environment.py
@@ -1,0 +1,6 @@
+import os
+
+
+QUEUE_NAME = os.getenv("GEMINI_MESSAGING_QUEUE_NAME", "gemini-messaging")
+RABBIT_HOST = os.getenv("RABBIT_HOST", "localhost")
+RABBIT_PORT = os.getenv("RABBIT_PORT", 5672)

--- a/microservices/chat-agents/gemini_executor.py
+++ b/microservices/chat-agents/gemini_executor.py
@@ -1,0 +1,82 @@
+import google.generativeai as genai
+from google.generativeai.types.generation_types import GenerateContentResponse
+import pika
+from pika.adapters.blocking_connection import BlockingChannel
+import argparse
+from argparse import Namespace
+import json
+from typing import Optional
+
+import pika.adapters.blocking_connection
+
+from constants import GEMINI_MODEL
+from environment import RABBIT_HOST, RABBIT_PORT, QUEUE_NAME
+
+
+model: Optional[genai.GenerativeModel] = None
+
+
+def prompt(model: genai.GenerativeModel, message: str) -> GenerateContentResponse:
+    message_formatted = {"role": "user", "parts": [message]}
+
+    return model.generate_content(message_formatted)
+
+
+def message_processor(ch, method, _properties, body):
+    global model
+
+    body_decoded = json.loads(body.decode())
+    message = body_decoded["input"]
+
+    response = prompt(model=model, message=message)
+    print(f"You: {message}")
+    print(f"Gemini: {response.text}")  # Replace this with mongo insert call
+
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+
+def init_model(api_key: str) -> genai.GenerativeModel:
+    global model
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel(model_name=GEMINI_MODEL)
+
+
+def consume_queue() -> BlockingChannel:
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(host=RABBIT_HOST, port=RABBIT_PORT)
+    )
+    channel = connection.channel()
+
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+
+    channel.basic_qos(prefetch_count=1)
+    channel.basic_consume(queue=QUEUE_NAME, on_message_callback=message_processor)
+
+    channel.start_consuming()
+    return channel
+
+
+def main(args: Namespace):
+    init_model(args.gemini_api_key)
+
+    channel = None
+    try:
+        channel = consume_queue()
+    except KeyboardInterrupt:
+        if channel:
+            channel.stop_consuming()
+            channel.close()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Gemini executor")
+    parser.add_argument("--gemini-api-key", required=True, help="Gemini API key")
+
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    main(args=parse_args())

--- a/microservices/chat-agents/send_prompt.py
+++ b/microservices/chat-agents/send_prompt.py
@@ -1,0 +1,35 @@
+# JUST FOR LOCAL TESTING, DO NOT DEPLOY
+
+import pika
+import json
+import argparse
+
+from environment import RABBIT_HOST, RABBIT_PORT, QUEUE_NAME
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send prompt to chat-agents")
+    parser.add_argument("message", type=str, help="Message to send to chat-agents")
+
+    args = parser.parse_args()
+
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(host=RABBIT_HOST, port=RABBIT_PORT)
+    )
+    channel = connection.channel()
+
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+
+    message = json.dumps({"input": args.message})
+    channel.basic_publish(
+        exchange="",
+        routing_key=QUEUE_NAME,
+        body=message,
+        properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
+    )
+    print(f" [x] Sent '{message}'")
+    connection.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Implementation**

- Add a simple producer that pushes messages from command line argument to a RabbitMQ queue.
- Add a consumer that listens to this queue, consumes messages, sends to Gemini API and prints the result.

**TODO**

- Replace printing Gemini API result to pushing to MongoDB. 
- Add basic error handling, and refactor this horrible code. 