### PR TITLE
Add transitions to CO, ASK_U, and ASK_G states

### DIFF
--- a/microservices/chat-agents/chat_agents/handler_factory.py
+++ b/microservices/chat-agents/chat_agents/handler_factory.py
@@ -1,0 +1,22 @@
+from .state_handlers import (
+    Handler,
+    PromptHandler,
+    CommenceHandlder,
+    CommunicationHandler,
+)
+from .state_handlers import AskGeminiHandler, AskUserHandler, TerminalHandler
+from .prompt_inputs import PromptState
+from .gemini import GeminiAPIDao
+
+
+def prompt_handler_factory(state: PromptState, model: GeminiAPIDao) -> Handler:
+    handler = {
+        "PROMPT": PromptHandler,
+        "COMMENCE": CommenceHandlder,
+        "COMMUNICATE": CommunicationHandler,
+        "ASK_GEMINI": AskGeminiHandler,
+        "ASK_USER": AskUserHandler,
+        "TERMINAL": TerminalHandler,
+    }
+
+    return handler[state](model=model)

--- a/microservices/chat-agents/chat_agents/mongo_ops.py
+++ b/microservices/chat-agents/chat_agents/mongo_ops.py
@@ -36,5 +36,7 @@ class PromptInputDao:
             prompt_id = ObjectId()
 
         return self.__collection.update_one(
-            {"_id": prompt_id}, {"$set": prompt_input.model_dump()}, upsert=True
+            {"_id": ObjectId(prompt_id)},
+            {"$set": prompt_input.model_dump()},
+            upsert=True,
         )

--- a/microservices/chat-agents/chat_agents/prompt_inputs.py
+++ b/microservices/chat-agents/chat_agents/prompt_inputs.py
@@ -26,6 +26,9 @@ class QueueRequest(BaseModel):
 class StateMachineQueueRequest(QueueRequest):
     from_uid: str
     to_uid: str
-    your_summary: str
-    their_summary: str
+    u1_summary: str
+    u2_summary: str
+    target: str
+    questions: Optional[str] = ""
     previous_response: Optional[str] = ""
+    interaction_id: Optional[str] = ""

--- a/microservices/chat-agents/chat_agents/queue/__init__.py
+++ b/microservices/chat-agents/chat_agents/queue/__init__.py
@@ -1,0 +1,2 @@
+from .consumer import Consumer
+from .publisher import publish_message

--- a/microservices/chat-agents/chat_agents/queue/consumer.py
+++ b/microservices/chat-agents/chat_agents/queue/consumer.py
@@ -4,36 +4,16 @@ import json
 import pydantic
 from typing import Optional, Union
 
-from .singleton import singleton
-from .environment import QUEUE_NAME, RABBIT_HOST, RABBIT_PORT
-from .gemini import GeminiAPIDao
-from .prompt_inputs import QueueRequest, StateMachineQueueRequest
-from .logger import Logger, LogLevel
-from .state_handlers import (
-    Handler,
-    PromptHandler,
-    CommenceHandlder,
-    CommunicationHandler,
-)
-from .state_handlers import AskGeminiHandler, AskUserHandler, TerminalHandler
-from .prompt_inputs import PromptState
-
-
-def prompt_handler_factory(state: PromptState, model: GeminiAPIDao) -> Handler:
-    handler = {
-        PromptState.PROMPT: PromptHandler,
-        PromptState.COMMENCE: CommenceHandlder,
-        PromptState.COMMUNICATE: CommunicationHandler,
-        PromptState.ASK_GEMINI: AskGeminiHandler,
-        PromptState.ASK_USER: AskUserHandler,
-        PromptState.TERMINAL: TerminalHandler,
-    }
-
-    return handler[state](model=model)
+from ..singleton import singleton
+from ..environment import QUEUE_NAME, RABBIT_HOST, RABBIT_PORT
+from ..gemini import GeminiAPIDao
+from ..prompt_inputs import QueueRequest, StateMachineQueueRequest
+from ..logger import Logger, LogLevel
+from ..handler_factory import prompt_handler_factory
 
 
 @singleton
-class QueueListener:
+class Consumer:
     def __init__(self, model: GeminiAPIDao) -> None:
         self.__channel = self.__init_channel()
         self.__model = model

--- a/microservices/chat-agents/chat_agents/queue/publisher.py
+++ b/microservices/chat-agents/chat_agents/queue/publisher.py
@@ -1,0 +1,27 @@
+from typing import Union
+import pika
+
+from ..prompt_inputs import QueueRequest, StateMachineQueueRequest
+from ..environment import RABBIT_HOST, RABBIT_PORT, QUEUE_NAME
+from ..logger import Logger, LogLevel
+
+
+def publish_message(message: Union[QueueRequest, StateMachineQueueRequest]) -> None:
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(host=RABBIT_HOST, port=RABBIT_PORT)
+    )
+    channel = connection.channel()
+
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+
+    try:
+        channel.basic_publish(
+            exchange="",
+            routing_key=QUEUE_NAME,
+            body=message.model_dump_json(),
+            properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
+        )
+    except Exception as e:
+        Logger().log(LogLevel.ERROR, f"Failed to publish message: {e}")
+
+    connection.close()

--- a/microservices/chat-agents/chat_agents/state_handlers/ask_gemini_handler.py
+++ b/microservices/chat-agents/chat_agents/state_handlers/ask_gemini_handler.py
@@ -2,8 +2,9 @@ from typing import Union, Optional
 
 from ..singleton import singleton
 from ..gemini import GeminiAPIDao
-from ..prompt_inputs import QueueRequest, StateMachineQueueRequest
+from ..prompt_inputs import QueueRequest, StateMachineQueueRequest, PromptState
 from ..logger import Logger, LogLevel
+from ..queue.publisher import publish_message
 from .handler import Handler
 
 
@@ -12,15 +13,49 @@ from .handler import Handler
 class AskGeminiHandler(Handler):
     def __init__(self, model: GeminiAPIDao) -> None:
         self.__model = model
+        self.__prompt_template = """
+This is what you know about a person: <KNOWLEDGE>{user_summary}</KNOWLEDGE>. 
+Given this, answer the following question in <ASK>[question]<ASK> tags: {questions}
+
+For questions whose answer is not in <KNOWLEDGE> return the same questions in <ASK>[question]</ASK> format. 
+If the answer is in <KNOWLEDGE> return only the answer in <ANS>[answer]</ANS> format. Do not make up facts.
+If you add <ANS>[answer]</ANS> do not copy the <ASK>[question]</ASK>.
+"""
 
     def execute(
         self, prompt_request: Union[QueueRequest, StateMachineQueueRequest]
     ) -> Optional[str]:
-        return None
+        if (
+            isinstance(prompt_request, QueueRequest)
+            and type(prompt_request) != StateMachineQueueRequest
+        ):
+            Logger().log(
+                LogLevel.ERROR,
+                "COMMENCE HANDLER: QueueRequest is not supported, must be StateMachineQueueRequest",
+            )
+            return None
+
+        prompt_request_dict = prompt_request.model_dump()
+        target = prompt_request.target
+        prompt = self.__prompt_template.format(
+            user_summary=prompt_request_dict[f"{target}_summary"],
+            questions=prompt_request.questions,
+        )
+        model_response = self.__model.prompt(message=prompt)
+        print(f"ASK_GEMINI: {model_response}")
+        return model_response
 
     def transition(
         self,
         prompt_request: Union[QueueRequest, StateMachineQueueRequest],
         model_output: Optional[str] = None,
     ) -> None:
-        pass
+        questions = super()._extract_text_between_tags(model_output, "ASK")
+
+        if len(questions) > 0:
+            transition_request = prompt_request.model_copy(deep=True)
+            transition_request.questions = questions
+            transition_request.state = PromptState.ASK_USER
+            publish_message(message=transition_request)
+        else:
+            pass  # Transition to COMM

--- a/microservices/chat-agents/chat_agents/state_handlers/ask_user_handler.py
+++ b/microservices/chat-agents/chat_agents/state_handlers/ask_user_handler.py
@@ -4,6 +4,7 @@ from ..singleton import singleton
 from ..gemini import GeminiAPIDao
 from ..prompt_inputs import QueueRequest, StateMachineQueueRequest
 from ..logger import Logger, LogLevel
+from ..mongo_ops import PromptInputDao
 from .handler import Handler
 
 
@@ -16,6 +17,25 @@ class AskUserHandler(Handler):
     def execute(
         self, prompt_request: Union[QueueRequest, StateMachineQueueRequest]
     ) -> Optional[str]:
+        if (
+            isinstance(prompt_request, QueueRequest)
+            and type(prompt_request) != StateMachineQueueRequest
+        ):
+            Logger().log(
+                LogLevel.ERROR,
+                "COMMENCE HANDLER: QueueRequest is not supported, must be StateMachineQueueRequest",
+            )
+            return None
+
+        questions = super()._extract_text_between_tags(prompt_request.questions, "ASK")
+
+        if len(questions) == 0:
+            return None
+
+        PromptInputDao().upsert(
+            prompt_input=prompt_request, prompt_id=prompt_request.interaction_id
+        )
+        print(f"ASK_USER: Posted to user!")
         return None
 
     def transition(
@@ -23,4 +43,7 @@ class AskUserHandler(Handler):
         prompt_request: Union[QueueRequest, StateMachineQueueRequest],
         model_output: Optional[str] = None,
     ) -> None:
-        pass
+        questions = super()._extract_text_between_tags(model_output, "ASK")
+
+        if len(questions) == 0:
+            pass  # Transition to COMM

--- a/microservices/chat-agents/chat_agents/state_handlers/handler.py
+++ b/microservices/chat-agents/chat_agents/state_handlers/handler.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional
+import re
 
 from ..prompt_inputs import QueueRequest, StateMachineQueueRequest
 
@@ -19,3 +20,15 @@ class Handler:
         raise NotImplementedError(
             "Do not use the base handler class directly. Use a subclass instead."
         )
+
+    def _extract_text_between_tags(self, text, tag):
+        pattern = f"<{tag}>(.*?)</{tag}>"
+        matches = re.findall(pattern, text, re.DOTALL)
+        matches = [f"<{tag}>{match}</{tag}>" for match in matches]
+        return "\n".join(matches)
+
+    def _extract_text_outside_tags(self, text, tag):
+        pattern = f"<{tag}>.*?</{tag}>"
+        segments = re.split(pattern, text, flags=re.DOTALL)
+        result = "".join([re.sub(r"\s+", " ", segment.strip()) for segment in segments])
+        return result

--- a/microservices/chat-agents/gemini_executor.py
+++ b/microservices/chat-agents/gemini_executor.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 
 from chat_agents.gemini import GeminiAPIDao
-from chat_agents.queue_listener import QueueListener
+from chat_agents.queue import Consumer
 
 
 def main(args: Namespace):
     model = GeminiAPIDao(api_key=args.gemini_api_key)
-    queue_listener = QueueListener(model)
+    queue_listener = Consumer(model=model)
 
     try:
         queue_listener.start_listening()

--- a/microservices/chat-agents/send_prompt.py
+++ b/microservices/chat-agents/send_prompt.py
@@ -1,12 +1,10 @@
 # JUST FOR LOCAL TESTING, DO NOT DEPLOY
 
-import pika
-import json
 import argparse
 
-from chat_agents.environment import RABBIT_HOST, RABBIT_PORT, QUEUE_NAME
 from chat_agents.mongo_ops import PromptInputDao
 from chat_agents.prompt_inputs import QueueRequest, StateMachineQueueRequest
+from chat_agents.queue import publish_message
 
 
 def main():
@@ -15,33 +13,19 @@ def main():
 
     args = parser.parse_args()
 
-    connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host=RABBIT_HOST, port=RABBIT_PORT)
-    )
-    channel = connection.channel()
-
-    channel.queue_declare(queue=QUEUE_NAME, durable=True)
-
     message = StateMachineQueueRequest(
         input=args.message,
         state="COMMENCE",
         from_uid="1",
         to_uid="2",
-        your_summary="This individual is a passionate programmer who enjoys coding and is currently learning C++. They find solace in watching movies and enjoying good food during their free time.  Their ultimate dream would be to code all day long, showcasing their dedication to the field. They are proud of the programs they have created, suggesting a strong work ethic and a desire for continuous learning.",
-        their_summary="This person is passionate about cooking and has a desire to learn how to play the flute. They are proud of climbing Mount Everest, a significant accomplishment. While they are not particularly fond of books, movies, or art, they are interested in traveling to Japan to see Mount Fuji.",
+        u1_summary="This individual is a passionate programmer who enjoys coding and is currently learning C++. They find solace in watching movies and enjoying good food during their free time.  Their ultimate dream would be to code all day long, showcasing their dedication to the field. They are proud of the programs they have created, suggesting a strong work ethic and a desire for continuous learning.",
+        u2_summary="This person is passionate about cooking and has a desire to learn how to play the flute. They are proud of climbing Mount Everest, a significant accomplishment. While they are not particularly fond of books, movies, or art, they are interested in traveling to Japan to see Mount Fuji.",
+        target="u1",
     )
 
-    out = PromptInputDao().upsert(message)
-    print(out)
-
-    # channel.basic_publish(
-    #     exchange="",
-    #     routing_key=QUEUE_NAME,
-    #     body=message.model_dump(),
-    #     properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
-    # )
-    # print(f" [x] Sent '{message}'")
-    connection.close()
+    res = PromptInputDao().upsert(prompt_input=message)
+    message.interaction_id = str(res.upserted_id)
+    publish_message(message=message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Implementation**

1. Moved queue listener (consumer) to a separate sub-module - `queue`, added a publisher helper which can be used by test script (`send_prompt.py`) and by various state handlers during transitioning.
2. Added transition from `CO` -> `ASK_G`, `ASK_G` -> `ASK_U`. 


**Current High Level Status**

- On beginning interaction a document is added to mongo store and interaction id is captured (will be returned from `POST /initiate`), it goes to `CO` state, processes and transitions to `ASK_G` if there are questions, if no questions does nothing for now (later will transition to `COMM`). 
- On `ASK_G` it executes using the summary to try to answer questions, if it can't it leaves them to be transitioned to `ASK_U`. If all questions are answered it should transition to `COMM` (not done yet).
- On `ASK_U`, it checks for questions, if all are answered it does nothing during execution, if not it updates the interaction document using the interaction id. The questions can then be answered by the actual human user. The transition is just to check if all questions are answered, if not then do nothing, otherwise transition to `COMM` (not done yet). 