### PR TITLE
Update chat agents rabbit consumer to use generic one

### DIFF
--- a/microservices/chat-agents-executor/chat_agents_executor/queue/__init__.py
+++ b/microservices/chat-agents-executor/chat_agents_executor/queue/__init__.py
@@ -1,1 +1,1 @@
-from .consumer import Consumer
+from .consumer import ChatAgentsConsumer

--- a/microservices/chat-agents-executor/gemini_executor.py
+++ b/microservices/chat-agents-executor/gemini_executor.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 
 from chat_agents_executor.gemini import GeminiAPIDao
-from chat_agents_executor.queue import Consumer
+from chat_agents_executor.queue import ChatAgentsConsumer
 
 
 def main(args: Namespace):
     model = GeminiAPIDao(api_key=args.gemini_api_key)
-    queue_listener = Consumer(model=model)
+    queue_listener = ChatAgentsConsumer(model=model)
 
     try:
         queue_listener.start_listening()


### PR DESCRIPTION
**Implementation**

1. Moved most parts of rabbit consumer class in `chat-agents-executor` to [persona-sync-pylib](https://github.com/frankhart2018/persona-sync-pylib). 