### PR TITLE
Add user question filtering in ASK_U state

### DIFF
--- a/microservices/chat-agents-executor/chat_agents_executor/state_handlers/ask_user_handler.py
+++ b/microservices/chat-agents-executor/chat_agents_executor/state_handlers/ask_user_handler.py
@@ -1,4 +1,5 @@
-from typing import Union, Optional
+from typing import Union, Optional, List
+from dataclasses import dataclass
 from persona_sync_pylib.queue import publish_chat_agents_message
 from persona_sync_pylib.utils.singleton import singleton
 from persona_sync_pylib.types.chat_agents import (
@@ -6,6 +7,8 @@ from persona_sync_pylib.types.chat_agents import (
     StateMachineQueueRequest,
     PromptState,
     UserQuestion,
+    UserQuestionState,
+    QAndA,
 )
 from persona_sync_pylib.utils.logger import Logger, LogLevel
 
@@ -14,6 +17,12 @@ from ..store.user_questions_dao import UserQuestionsDao
 from ..utils.gemini import GeminiAPIDao
 from ..utils.environment import QUEUE_NAME
 from .handler import Handler
+
+
+@dataclass
+class QuestionAndEmbedding:
+    question: QAndA
+    embedding: List[float]
 
 
 @singleton
@@ -37,27 +46,65 @@ class AskUserHandler(Handler):
         prompt_request_dict = prompt_request.model_dump()
         q_and_a_s = prompt_request.q_and_a_s
         answered_q_and_a_s = []
-        unanswered_q_and_a_s = []
+        unanswered_q_and_a_s: List[QuestionAndEmbedding] = []
+
+        all_user_questions = UserQuestionsDao().find_questions_for_user(
+            user_id=prompt_request_dict[f"{prompt_request.target}_uid"]
+        )
+
+        accept_score = 0
+        reject_score = 0
+        num_accepted = 0
+        num_rejected = 0
 
         for q_and_a in q_and_a_s:
             if q_and_a.answer:
                 answered_q_and_a_s.append(q_and_a)
             else:
                 embedding = GeminiAPIDao().get_embeddings(message=q_and_a.question)
-                user_question = UserQuestion(
-                    user_id=prompt_request_dict[f"{prompt_request.target}_uid"],
-                    question=q_and_a.question,
-                    question_embedding=embedding,
-                    interaction_id=prompt_request.interaction_id,
-                    question_id=q_and_a.obj_id,
+                unanswered_q_and_a_s.append(
+                    QuestionAndEmbedding(question=q_and_a, embedding=embedding)
                 )
-                UserQuestionsDao().insert(user_question)
 
-                unanswered_q_and_a_s.append(q_and_a)
+        filtered_unanswered_q_and_a_s = []
+        for qa_and_embedding in unanswered_q_and_a_s:
+            q_and_a = qa_and_embedding.question
+            embedding = qa_and_embedding.embedding
 
-        if len(unanswered_q_and_a_s) == 0:
-            print(f"ASK_USER: No questions to ask!")
-            return "To COMM"
+            for user_question in all_user_questions:
+                if user_question.state == UserQuestionState.ANSWERED:
+                    accept_score += GeminiAPIDao().get_similarity_score(
+                        embedding_1=embedding,
+                        embedding_2=user_question.question_embedding,
+                    )
+                    num_accepted += 1
+                elif user_question.state == UserQuestionState.REJECTED:
+                    reject_score += GeminiAPIDao().get_similarity_score(
+                        embedding_1=embedding,
+                        embedding_2=user_question.question_embedding,
+                    )
+                    num_rejected += 1
+
+            avg_accept_score = accept_score / num_accepted if num_accepted > 0 else 0
+            avg_reject_score = reject_score / num_rejected if num_rejected > 0 else 0
+
+            if avg_accept_score >= avg_reject_score:
+                UserQuestionsDao().insert(
+                    user_question=UserQuestion(
+                        user_id=prompt_request_dict[f"{prompt_request.target}_uid"],
+                        question=q_and_a.question,
+                        question_embedding=embedding,
+                        question_id=q_and_a.obj_id,
+                        interaction_id=prompt_request.interaction_id,
+                        state=UserQuestionState.PENDING,
+                        answer="",
+                    )
+                )
+                filtered_unanswered_q_and_a_s.append(q_and_a)
+
+        if len(filtered_unanswered_q_and_a_s) == 0:
+            print(f"ASK_USER: No worthy questions to ask!")
+            return None
         else:
             PromptInputDao().upsert(
                 prompt_input=prompt_request, prompt_id=prompt_request.interaction_id
@@ -70,6 +117,4 @@ class AskUserHandler(Handler):
         prompt_request: Union[QueueRequest, StateMachineQueueRequest],
         model_output: str,
     ) -> None:
-        transition_request = prompt_request.model_copy(deep=True)
-        transition_request.state = PromptState.COMMUNICATE
-        publish_chat_agents_message(message=transition_request, queue_name=QUEUE_NAME)
+        pass

--- a/microservices/chat-agents-executor/chat_agents_executor/store/user_questions_dao.py
+++ b/microservices/chat-agents-executor/chat_agents_executor/store/user_questions_dao.py
@@ -1,7 +1,9 @@
 from pymongo.results import InsertOneResult
+import json
+from typing import List
 from persona_sync_pylib.utils.singleton import singleton
 from persona_sync_pylib.utils.mongo_ops import MongoCollection
-from persona_sync_pylib.types.chat_agents import UserQuestion
+from persona_sync_pylib.types.chat_agents import UserQuestion, UserQuestionState
 
 from ..utils.environment import MONGO_DB_NAME, USER_QUESTIONS_COLLECTION
 
@@ -14,4 +16,20 @@ class UserQuestionsDao:
         )
 
     def insert(self, user_question: UserQuestion) -> InsertOneResult:
-        return self.__collection.insert_one(user_question.model_dump())
+        return self.__collection.insert_one(json.loads(user_question.model_dump_json()))
+
+    def find_questions_for_user(self, user_id: str) -> List[UserQuestion]:
+        user_questions = self.__collection.find_one(
+            {
+                "user_id": user_id,
+                "state": {
+                    "$in": [
+                        UserQuestionState.ANSWERED.value,
+                        UserQuestionState.REJECTED.value,
+                    ]
+                },
+            }
+        )
+        if user_questions:
+            return [UserQuestion(**user_question) for user_question in user_questions]
+        return []

--- a/microservices/chat-agents-executor/chat_agents_executor/utils/gemini.py
+++ b/microservices/chat-agents-executor/chat_agents_executor/utils/gemini.py
@@ -1,5 +1,7 @@
 import google.generativeai as genai
 from typing import Optional, List
+import numpy as np
+from numpy.linalg import norm
 from persona_sync_pylib.utils.singleton import singleton
 from persona_sync_pylib.utils.logger import Logger, LogLevel
 
@@ -33,3 +35,10 @@ class GeminiAPIDao:
         except Exception as e:
             Logger().log(LogLevel.ERROR, f"Failed to generate embeddings: {e}")
             return []
+
+    def get_similarity_score(
+        self, embedding_1: List[float], embedding_2: List[float]
+    ) -> float:
+        return np.dot(embedding_1, embedding_2) / (
+            norm(embedding_1) * norm(embedding_2)
+        )


### PR DESCRIPTION
Closes #2 

**Implementation**

1. Computes the embedding of all unanswered questions.
2. Gets cosine similarity with existing questions: both answered and unanswered.
3. Computes average answered and rejected score, if $avg_\{answered} \geq avg_\{rejected}$ then accept otherwise reject. 
4. On acceptance post the filtered out questions (which can be equal to all unanswered questions).

- Removed transition to `COMM` state, that should be done when submitting the prompt input with answered questions. 