### PR TITLE
Add prompt result in db

### DIFF
--- a/microservices/chat-agents-executor/chat_agents_executor/state_handlers/prompt_handler.py
+++ b/microservices/chat-agents-executor/chat_agents_executor/state_handlers/prompt_handler.py
@@ -3,6 +3,7 @@ from persona_sync_pylib.utils.singleton import singleton
 from persona_sync_pylib.types.chat_agents import QueueRequest, StateMachineQueueRequest
 
 from ..utils.gemini import GeminiAPIDao
+from ..store.prompt_input_dao import PromptInputDao
 from .handler import Handler
 
 
@@ -15,8 +16,12 @@ class PromptHandler(Handler):
         self, prompt_request: Union[QueueRequest, StateMachineQueueRequest]
     ) -> Optional[str]:
         model_response = self.__model.prompt(message=prompt_request.input)
-        print(f"You: {prompt_request.input}")
-        print(f"Gemini: {model_response}")  # Replace this with mongo insert call
+
+        print(f"PROMPT: {model_response}")
+
+        result = prompt_request.model_copy(deep=True)
+        result.previous_response = model_response
+        PromptInputDao().upsert(prompt_input=result, prompt_id=result.interaction_id)
 
         return None
 

--- a/microservices/gemini-agents-service/app/model/prompt_request.py
+++ b/microservices/gemini-agents-service/app/model/prompt_request.py
@@ -4,6 +4,7 @@ from persona_sync_pylib.types.chat_agents import QueueRequest
 
 class PromptHTTPRequest(BaseModel):
     prompt: str
+    poll: bool = False
 
 
 class PromptRabbitRequest(QueueRequest):

--- a/microservices/gemini-agents-service/app/store/prompt_input_dao.py
+++ b/microservices/gemini-agents-service/app/store/prompt_input_dao.py
@@ -1,8 +1,13 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Union
+import pydantic
 from bson.objectid import ObjectId
 from persona_sync_pylib.utils.singleton import singleton
 from persona_sync_pylib.utils.mongo_ops import MongoCollection
-from persona_sync_pylib.types.chat_agents import QAndA
+from persona_sync_pylib.types.chat_agents import (
+    QAndA,
+    QueueRequest,
+    StateMachineQueueRequest,
+)
 
 from app.utils.environment import MONGO_DB_NAME, PROMPT_INPUTS_COLLECTION
 
@@ -22,3 +27,18 @@ class PromptInputDao:
             {"$set": {"q_and_a_s": q_and_a_s}},
             return_document=True,
         )
+
+    def get_prompt_input(
+        self, prompt_id: str
+    ) -> Optional[Union[QueueRequest, StateMachineQueueRequest]]:
+        result = self.__collection.find_one({"_id": ObjectId(prompt_id)})
+        if result is None:
+            return None
+
+        try:
+            return StateMachineQueueRequest(**result)
+        except pydantic.ValidationError as pe:
+            try:
+                return QueueRequest(**result)
+            except pydantic.ValidationError:
+                return None


### PR DESCRIPTION
**Fixes**

1. The prompt API just submitted the prompt to the queue, there was no way to fetch the result, which was not optimal.
2. Added interaction id generated in API side, passed to prompt to upsert the results into.
3. Added an option to just return with interaction id or do long polling for the result. 